### PR TITLE
Lock netdata version to 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Role Variables
 |----------------------------------|----------|------------------------|-----------|---------------------------------------------------|
 | netdata_dependencies             | true     |                        | list      | See `defaults/main.yml`.                          |
 | netdata_version                  | true     | `2.1.1`                | string    | Locked to 2.1.1 before the 5 active nodes limit.  |
+| netdata_packages                 | true     |                        | list      | See `defaults/main.yml`.                          |
 | netdata_package_state            | true     | `present`              | string    |                                                   |
 | netdata_pip_packages             | true     | `[]`                   | list      | Extra pip packages to install.                    |
 | netdata_user_extra_groups        | true     | `[]`                   | list      | Extra Unix groups for the Netdata user.           |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Role Variables
 | Variable                         | Required | Default                | Choices   | Comments                                          |
 |----------------------------------|----------|------------------------|-----------|---------------------------------------------------|
 | netdata_dependencies             | true     |                        | list      | See `defaults/main.yml`.                          |
+| netdata_version                  | true     | `2.1.1`                | string    | Locked to 2.1.1 before the 5 active nodes limit.  |
 | netdata_package_state            | true     | `present`              | string    |                                                   |
 | netdata_pip_packages             | true     | `[]`                   | list      | Extra pip packages to install.                    |
 | netdata_user_extra_groups        | true     | `[]`                   | list      | Extra Unix groups for the Netdata user.           |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,18 @@ netdata_dependencies:
   - python3-debian
 
 netdata_version: 2.1.1
+netdata_packages:
+  - "netdata={{ netdata_version }}"
+  - "netdata-dashboard={{ netdata_version }}"
+  - "netdata-plugin-apps={{ netdata_version }}"
+  - "netdata-plugin-chartsd={{ netdata_version }}"
+  - "netdata-plugin-debugfs={{ netdata_version }}"
+  - "netdata-plugin-ebpf={{ netdata_version }}"
+  - "netdata-plugin-go={{ netdata_version }}"
+  - "netdata-plugin-nfacct={{ netdata_version }}"
+  - "netdata-plugin-perf={{ netdata_version }}"
+  - "netdata-plugin-pythond={{ netdata_version }}"
+  - "netdata-plugin-slabinfo={{ netdata_version }}"
 netdata_package_state: present
 
 netdata_pip_packages: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@ netdata_dependencies:
   - gnupg
   - python3-debian
 
+netdata_version: 2.1.1
 netdata_package_state: present
 
 netdata_pip_packages: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Ensure Netdata is installed
   ansible.builtin.apt:
-    name: "{{ netdata_package_name }}"
+    name: "{{ netdata_package_name }}={{ netdata_version }}"
     state: "{{ netdata_package_state }}"
     update_cache: true
   notify: Restart Netdata

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Ensure Netdata is installed
   ansible.builtin.apt:
-    name: "{{ netdata_package_name }}={{ netdata_version }}"
+    name: "{{ netdata_packages }}"
     state: "{{ netdata_package_state }}"
     update_cache: true
   notify: Restart Netdata


### PR DESCRIPTION
Newer versions enforce the 5 active nodes limit preventing cloudless Netdata to be used on-premises.
Dashboard is accessible on `https://netdata-domain/v3`.
